### PR TITLE
Update steam-friend.h

### DIFF
--- a/steam/steam-friend.h
+++ b/steam/steam-friend.h
@@ -22,7 +22,6 @@
 
 typedef enum   _SteamFriendAction   SteamFriendAction;
 typedef enum   _SteamFriendRelation SteamFriendRelation;
-typedef enum   _SteamFriendRelation SteamFriendRelation;
 typedef enum   _SteamFriendState    SteamFriendState;
 typedef struct _SteamFriend         SteamFriend;
 typedef struct _SteamFriendSummary  SteamFriendSummary;


### PR DESCRIPTION
Removed line 25, it was copy of line 24, and this gives error on some compiling enviroments:

steam-friend.h:25: error: redefinition of typedef ‘SteamFriendRelation’
steam-friend.h:24: note: previous declaration of ‘SteamFriendRelation’ was here
