### PR TITLE
Add headers to source distributions

### DIFF
--- a/steam/Makefile.am
+++ b/steam/Makefile.am
@@ -10,7 +10,15 @@ steam_la_SOURCES = \
 	steam-http.c \
 	steam-json.c \
 	steam-user.c \
-	steam-util.c
+	steam-util.c \
+	steam.h \
+	steam-api.h \
+	steam-crypt.h \
+	steam-http.h \
+	steam-id.h \
+	steam-json.h \
+	steam-user.h \
+	steam-util.h
 
 # Build the library as a module
 steam_la_LDFLAGS += -module -avoid-version


### PR DESCRIPTION
Source tarballs generated by ``make dist'' currently don't build because they don't contain headers.  This commit adds the headers to steam_la_SOURCES to make automake start including them.
