### PR TITLE
Shell portability: Use the = test(1) operator instead of ==.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ AC_ARG_ENABLE(
 )
 
 AS_IF(
-    [test "x$WARNINGS" == "xyes"],
+    [test "x$WARNINGS" = "xyes"],
     [CFLAGS="$CFLAGS -Wall -Wextra \
      -Waggregate-return \
      -Wdeclaration-after-statement \


### PR DESCRIPTION
== is a GNU extension.